### PR TITLE
feature(db): make a db using the PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,9 @@ repositories {
 }
 
 dependencies {
+	//add postgreSQL driver
+	runtimeOnly 'org.postgresql:postgresql'
+
 	//add lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/example/springbasic/entity/Article.java
+++ b/src/main/java/com/example/springbasic/entity/Article.java
@@ -12,6 +12,7 @@ import javax.persistence.*;
 @AllArgsConstructor
 @ToString
 @Getter
+@Table(name = "article")
 public class Article {
 
     @Id //unique key

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,12 +7,20 @@ spring:
         web-allow-others: true
   jpa:
     defer-datasource-initialization: true
+    hibernate:
+      ddl-auto: update
     properties:  #for a good-looking
       hibernate:
         format_sql: true
+
   datasource: #fix the DB URL
     generate-unique-name: false #don't make unique URL
-    url: jdbc:h2:mem:testdb #set fixed URL
+    #url: jdbc:h2:mem:testdb #set fixed URL (<- previous url)
+    url: jdbc:postgresql://127.0.0.1:5432/springbasicpostgres #link to postgreSQL
+    username: gomgom
+    password: hg
+    data: classpath:data.sql
+    initialization-mode: never
 
 #set JPA logging
 #print query at debug level
@@ -25,4 +33,3 @@ logging:
           descriptor:
             sql:
               BasicBinder: trace #show parameter
-


### PR DESCRIPTION
# feature(db): make a db using the PostgreSQL
- prevent data reset when server restarts
- maintain the change in the data regardless of the server's restart
---
- 1 issue happens
- issue: org.postgresql.util.PSQLException: 오류: "posts" 이름의 릴레이션(relation)이 없습니다
- reason: entity wasn't created when the server restarts
- solution: add `spring.jpa.hibernate.ddl-auto=create-drop`